### PR TITLE
Fix broken paths in mech interp demo

### DIFF
--- a/Othello_GPT_Circuits.ipynb
+++ b/Othello_GPT_Circuits.ipynb
@@ -382,8 +382,8 @@
     }
    ],
    "source": [
-    "board_seqs_int = torch.tensor(np.load(OTHELLO_ROOT/\"board_seqs_int_small.npy\"), dtype=torch.long)\n",
-    "board_seqs_string = torch.tensor(np.load(OTHELLO_ROOT/\"board_seqs_string_small.npy\"), dtype=torch.long)\n",
+    "board_seqs_int = torch.tensor(np.load(OTHELLO_ROOT/\"mechanistic_interpretability/board_seqs_int_small.npy\"), dtype=torch.long)\n",
+    "board_seqs_string = torch.tensor(np.load(OTHELLO_ROOT/\"mechanistic_interpretability/board_seqs_string_small.npy\"), dtype=torch.long)\n",
     "\n",
     "num_games, length_of_game = board_seqs_int.shape\n",
     "print(\"Number of games:\", num_games,)\n",
@@ -836,7 +836,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "full_linear_probe = torch.load(OTHELLO_ROOT/\"main_linear_probe.pth\")"
+    "full_linear_probe = torch.load(OTHELLO_ROOT/\"mechanistic_interpretability/main_linear_probe.pth\")"
    ]
   },
   {


### PR DESCRIPTION
The Othello_GPT_Circuits.ipynb demo is currently broken since some files were moved. I modified some of the paths to fix this.